### PR TITLE
Release v0.1.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Checklist
+- [ ] My code follows the repository style guide and passes linting
+- [ ] I have run the test suite locally and all tests pass
+- [ ] I updated/added tests for my changes when applicable
+- [ ] I updated the Prisma schema and ran `prisma generate` when applicable
+- [ ] I ran database migrations (or included SQL/migration files) when applicable
+- [ ] I updated the changelog or release notes (if applicable)
+- [ ] I confirmed the CI workflow passes for this branch
+- [ ] I added deployment notes or migration instructions if this PR requires them
+
+## Reviewer notes
+- Add any notes, manual steps, or special instructions for reviewers here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this repository will be documented in this file.
+
+## [0.1.0] - 2025-09-28
+- Merged PR #8: chore(ci): add full API routes, seed, CI and cleanup
+  - Added TypeScript backend with Prisma schema, migrations, seed script
+  - Implemented CRUD routes (shelters, locations, pets, owners, pet-owners, medical, events)
+  - Added Zod validation, pino logging, Jest + SuperTest tests, and a GitHub Actions CI workflow
+  - Cleaned repository history and removed tracked node_modules and dev.db from source control


### PR DESCRIPTION
Release v0.1.0 — merges changes from chore/ci-tests (PR #8). Includes backend Prisma schema, routes, tests, CI, and repo cleanup. See CHANGELOG.md.