### PR TITLE
chore: remove stray tracked Vite cache file

### DIFF
--- a/test-frontend/.vite/deps/package.json
+++ b/test-frontend/.vite/deps/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "module"
-}


### PR DESCRIPTION
Remove accidentally tracked Vite cache file at test-frontend/.vite/deps/package.json left after the frontend swap.