### PR TITLE
chore(repo): remove test-frontend leftovers and ignore Vite caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ dist
 build
 frontend/dist
 frontend/.vite
+**/.vite/
+test-frontend/
 /.parcel-cache
 
 ### Editor

--- a/test-frontend/.vite/deps/_metadata.json
+++ b/test-frontend/.vite/deps/_metadata.json
@@ -1,8 +1,0 @@
-{
-  "hash": "0cf3d5d2",
-  "configHash": "edd8e24f",
-  "lockfileHash": "e3b0c442",
-  "browserHash": "a066346b",
-  "optimized": {},
-  "chunks": {}
-}


### PR DESCRIPTION
Remove remaining tracked test-frontend artifacts and harden .gitignore to ignore test-frontend/ and any **/.vite/ caches. This prevents Vite cache files from being accidentally committed again.