### PR TITLE
chore(release-please): switch to googleapis action and use PAT for PR creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Please
-        uses: google-github-actions/release-please-action@v4
+        # Use the recommended action (the google-github-actions variant is deprecated)
+        uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # Use a classic PAT with repo scope so PR creation works even if GITHUB_TOKEN
+          # is restricted from creating/approving pull requests in repo settings.
+          token: ${{ secrets.PROJECTS_TOKEN }}


### PR DESCRIPTION
Switches the workflow to googleapis/release-please-action@v4 and passes a PAT (PROJECTS_TOKEN) so the action can create PRs when GITHUB_TOKEN is restricted.\n\n- Uses a classic PAT with repo + project scopes already stored as PROJECTS_TOKEN.\n- Keeps monorepo config: backend (node), frontend (node), root aggregate (simple).\n- After merge, the release-please workflow should open a release PR from release-please--branches--main.