### PR TITLE
chore(frontend): correct lockfile name and add release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,13 @@ See `CHANGELOG.md`. Recent:
 - 0.2.1 (2025-10-04) — Mobile-only Team Switcher in header; documentation updates
 - 0.2.0 (2025-09-28) — Backend foundation, routes, seeds, CI
 
+## Release notes
+
+Latest releases (2025-10-05):
+- Root: v0.3.0 — https://github.com/BoldNight153/PetShelterRegistrySystem/releases/tag/v0.3.0
+- Backend: backend-v0.1.0 — https://github.com/BoldNight153/PetShelterRegistrySystem/releases/tag/backend-v0.1.0
+- Frontend: frontend-v1.0.0 — https://github.com/BoldNight153/PetShelterRegistrySystem/releases/tag/frontend-v1.0.0
+
 ## Project management
 
 We use a repo-level GitHub Project to plan and track work with milestones, issues, and PRs.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "test-frontend",
+  "name": "frontend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "test-frontend",
+      "name": "frontend",
       "version": "1.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
Cosmetic: change frontend/package-lock.json name from test-frontend to frontend and bump its version to 1.0.0 to match package.json. Also add a short Release notes section in README linking to v0.3.0, backend-v0.1.0, and frontend-v1.0.0.