### PR TITLE
feat(seed): add comprehensive settings_main menu

### DIFF
--- a/backend/prisma/migrations/20251113090000_add_user_metadata/migration.sql
+++ b/backend/prisma/migrations/20251113090000_add_user_metadata/migration.sql
@@ -1,0 +1,3 @@
+-- Add metadata column to store structured profile details
+-- Use a generic ADD clause (some SQL engines reject the 'COLUMN' keyword)
+ALTER TABLE "User" ADD "metadata" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -158,6 +158,7 @@ model User {
   auditLogs     AuditLog[]
   locks         UserLock[]
   passwordHistory PasswordHistory[]
+  metadata      Json?
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
 }

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -38,6 +38,76 @@ async function main() {
         await prisma.menuItem.create({ data: { menuId: mainMenu.id, title: 'Settings', url: '#', order: 20 } });
         console.log('Seeded default `main` menu with items');
     }
+    // Seed the full settings menu used by the admin UI (`settings_main`) — idempotent
+    const settingsMenu = await prisma.menu.upsert({
+        where: { name: 'settings_main' },
+        update: { title: 'Settings Menu', isActive: true },
+        create: { name: 'settings_main', title: 'Settings', description: 'Context-aware settings sections for administrators and staff', isActive: true }
+    });
+    const existingSettingsItems = await prisma.menuItem.findMany({ where: { menuId: settingsMenu.id } });
+    if (!existingSettingsItems.length) {
+        // Account & Profile
+        const accountGroup = await prisma.menuItem.create({ data: { menuId: settingsMenu.id, title: 'Account & Profile', order: 0, isPublished: true, isVisible: true } });
+        await prisma.menuItem.createMany({ data: [
+            { menuId: settingsMenu.id, parentId: accountGroup.id, title: 'Profile', url: '/settings/account/profile', order: 0, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: accountGroup.id, title: 'Security', url: '/settings/account/security', order: 1, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: accountGroup.id, title: 'Notifications', url: '/settings/account/notifications', order: 2, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: accountGroup.id, title: 'Connected Apps', url: '/settings/account/connected-apps', order: 3, isPublished: true, isVisible: true },
+        ] });
+
+        // Organization
+        const orgGroup = await prisma.menuItem.create({ data: { menuId: settingsMenu.id, title: 'Organization', order: 100, isPublished: true, isVisible: true } });
+        await prisma.menuItem.createMany({ data: [
+            { menuId: settingsMenu.id, parentId: orgGroup.id, title: 'Organization Settings', url: '/settings/organization', order: 0, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: orgGroup.id, title: 'Branding', url: '/settings/organization/branding', order: 1, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: orgGroup.id, title: 'Locations', url: '/settings/organization/locations', order: 2, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: orgGroup.id, title: 'Teams & Departments', url: '/settings/organization/teams', order: 3, isPublished: true, isVisible: true },
+        ] });
+
+        // Security & Access
+        const securityGroup = await prisma.menuItem.create({ data: { menuId: settingsMenu.id, title: 'Security & Access', order: 200, isPublished: true, isVisible: true } });
+        await prisma.menuItem.createMany({ data: [
+            { menuId: settingsMenu.id, parentId: securityGroup.id, title: 'Authentication', url: '/settings/security/authentication', order: 0, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: securityGroup.id, title: 'Session Policies', url: '/settings/security/sessions', order: 1, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: securityGroup.id, title: 'Roles & Permissions', url: '/settings/security/roles', order: 2, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: securityGroup.id, title: 'Audit Logs', url: '/settings/security/audit-logs', order: 3, isPublished: true, isVisible: true },
+        ] });
+
+        // Integrations & API
+        const integrationsGroup = await prisma.menuItem.create({ data: { menuId: settingsMenu.id, title: 'Integrations & API', order: 300, isPublished: true, isVisible: true } });
+        await prisma.menuItem.createMany({ data: [
+            { menuId: settingsMenu.id, parentId: integrationsGroup.id, title: 'Integration Catalog', url: '/settings/integrations/catalog', order: 0, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: integrationsGroup.id, title: 'API Access', url: '/settings/integrations/api', order: 1, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: integrationsGroup.id, title: 'Webhooks', url: '/settings/integrations/webhooks', order: 2, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: integrationsGroup.id, title: 'Developer Console', url: '/settings/integrations/dev-console', order: 3, isPublished: true, isVisible: true },
+        ] });
+
+        // Billing & Subscription
+        const billingGroup = await prisma.menuItem.create({ data: { menuId: settingsMenu.id, title: 'Billing & Subscription', order: 400, isPublished: true, isVisible: true } });
+        await prisma.menuItem.createMany({ data: [
+            { menuId: settingsMenu.id, parentId: billingGroup.id, title: 'Plan & Usage', url: '/settings/billing/plan', order: 0, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: billingGroup.id, title: 'Invoices', url: '/settings/billing/invoices', order: 1, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: billingGroup.id, title: 'Payment Methods', url: '/settings/billing/payment-methods', order: 2, isPublished: true, isVisible: true },
+        ] });
+
+        // Monitoring & Reliability
+        const monitoringGroup = await prisma.menuItem.create({ data: { menuId: settingsMenu.id, title: 'Monitoring & Reliability', order: 500, isPublished: true, isVisible: true } });
+        await prisma.menuItem.createMany({ data: [
+            { menuId: settingsMenu.id, parentId: monitoringGroup.id, title: 'System Health', url: '/settings/monitoring/health', order: 0, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: monitoringGroup.id, title: 'Alerting', url: '/settings/monitoring/alerting', order: 1, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: monitoringGroup.id, title: 'Data Retention', url: '/settings/monitoring/data-retention', order: 2, isPublished: true, isVisible: true },
+        ] });
+
+        // Documentation & Support
+        const docsGroup = await prisma.menuItem.create({ data: { menuId: settingsMenu.id, title: 'Documentation & Support', order: 600, isPublished: true, isVisible: true } });
+        await prisma.menuItem.createMany({ data: [
+            { menuId: settingsMenu.id, parentId: docsGroup.id, title: 'Knowledge Base', url: '/settings/docs/knowledge-base', order: 0, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: docsGroup.id, title: 'Release Notes', url: '/settings/docs/release-notes', order: 1, isPublished: true, isVisible: true },
+            { menuId: settingsMenu.id, parentId: docsGroup.id, title: 'Support Center', url: '/settings/docs/support', order: 2, isPublished: true, isVisible: true },
+        ] });
+
+        console.log('Seeded full `settings_main` menu with default sections and items');
+    }
 }
 main()
     .catch(e => {

--- a/backend/src/openapi-auth.yaml
+++ b/backend/src/openapi-auth.yaml
@@ -505,13 +505,71 @@ paths:
                   id: { type: string }
                   email: { type: string }
                   name: { type: ["string", "null"] }
+                  image: { type: ["string", "null"], format: uri }
                   emailVerified: { type: ["string", "null"], format: date-time }
+                  metadata:
+                    type: [object, "null"]
+                    additionalProperties: {}
                   roles:
                     type: array
                     items: { type: string }
                   permissions:
                     type: array
                     items: { type: string }
+                  createdAt: { type: string, format: date-time }
+                  updatedAt: { type: string, format: date-time }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+    put:
+      tags: [Auth]
+      summary: Update current authenticated user profile
+      description: |
+        Update basic profile fields for the authenticated user, including display name, avatar URL,
+        and optional extended metadata such as pronouns or timezone.
+      operationId: updateMe
+      security:
+        - cookieAuth: []
+        - csrfHeader: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name: { type: [string, 'null'] }
+                avatarUrl: { type: [string, 'null'], format: uri }
+                title: { type: [string, 'null'] }
+                department: { type: [string, 'null'] }
+                pronouns: { type: [string, 'null'] }
+                timezone: { type: [string, 'null'] }
+                locale: { type: [string, 'null'] }
+                phone: { type: [string, 'null'] }
+                bio: { type: [string, 'null'] }
+      responses:
+        "200":
+          description: Updated profile
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  email: { type: string }
+                  name: { type: ["string", "null"] }
+                  image: { type: ["string", "null"], format: uri }
+                  emailVerified: { type: ["string", "null"], format: date-time }
+                  metadata:
+                    type: [object, "null"]
+                    additionalProperties: {}
+                  roles:
+                    type: array
+                    items: { type: string }
+                  permissions:
+                    type: array
+                    items: { type: string }
+                  createdAt: { type: string, format: date-time }
+                  updatedAt: { type: string, format: date-time }
+        "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
 
   /auth/mode:

--- a/frontend/src/components/nav-user.tsx
+++ b/frontend/src/components/nav-user.tsx
@@ -120,6 +120,33 @@ export default function NavUser({ placement = "header" }: NavUserProps) {
 
   const effectiveQuickLinks = quickLinks.length > 0 ? quickLinks : fallbackQuickLinks
 
+  const avatarSrc = React.useMemo(() => {
+    if (user && typeof user === 'object') {
+      const img = (user as any).image
+      if (typeof img === 'string' && img.trim().length > 0) {
+        return img.trim()
+      }
+      const meta = user?.metadata as Record<string, unknown> | null | undefined
+      if (meta && typeof meta === 'object') {
+        const candidate = (meta as Record<string, unknown>)?.['avatarUrl']
+        if (typeof candidate === 'string' && candidate.trim().length > 0) {
+          return candidate.trim()
+        }
+      }
+    }
+    return '/avatars/shadcn.jpg'
+  }, [user])
+
+  const avatarFallbackText = React.useMemo(() => {
+    const source = (user?.name || user?.email || 'User').trim()
+    if (!source) return 'U'
+    const parts = source.split(/\s+/)
+    if (parts.length >= 2) {
+      return `${parts[0][0] ?? ''}${parts[1][0] ?? ''}`.toUpperCase() || 'U'
+    }
+    return source.slice(0, 2).toUpperCase() || 'U'
+  }, [user?.name, user?.email])
+
   const handleLink = React.useCallback(
     (link: QuickLink) => {
       if (link.external) {
@@ -205,8 +232,8 @@ export default function NavUser({ placement = "header" }: NavUserProps) {
               }
             >
               <Avatar className="h-8 w-8 rounded-lg">
-                <AvatarImage src="/avatars/shadcn.jpg" alt={user.name || user.email || "User"} />
-                <AvatarFallback className="rounded-lg">U</AvatarFallback>
+                <AvatarImage src={avatarSrc} alt={user?.name || user?.email || "User"} />
+                <AvatarFallback className="rounded-lg">{avatarFallbackText}</AvatarFallback>
               </Avatar>
               {!condensed && (
                 <>
@@ -228,8 +255,8 @@ export default function NavUser({ placement = "header" }: NavUserProps) {
             <DropdownMenuLabel className="p-0 font-normal">
               <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
                 <Avatar className="h-8 w-8 rounded-lg">
-                  <AvatarImage src="/avatars/shadcn.jpg" alt={user.name || user.email || "User"} />
-                  <AvatarFallback className="rounded-lg">U</AvatarFallback>
+                  <AvatarImage src={avatarSrc} alt={user?.name || user?.email || "User"} />
+                  <AvatarFallback className="rounded-lg">{avatarFallbackText}</AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
                   <span className="truncate font-medium">{user.name || user.email || 'User'}</span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -161,6 +161,33 @@ export async function me() {
   return res.json();
 }
 
+export type UpdateProfileInput = {
+  name?: string | null;
+  avatarUrl?: string | null;
+  title?: string | null;
+  department?: string | null;
+  pronouns?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
+  phone?: string | null;
+  bio?: string | null;
+};
+
+export async function updateProfile(input: UpdateProfileInput) {
+  const csrf = await getCsrfToken();
+  const res = await fetch(`${API_BASE}auth/me`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+    credentials: 'include',
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(typeof (err as any)?.error === 'string' ? (err as any).error : 'Failed to update profile');
+  }
+  return res.json();
+}
+
 // ----------------------
 // Admin Settings API
 // ----------------------

--- a/frontend/src/lib/header-login-flow.test.tsx
+++ b/frontend/src/lib/header-login-flow.test.tsx
@@ -14,7 +14,18 @@ const meMock = vi.fn(async () => null)
 
 describe('Header switches after login', () => {
   it('shows NavUser after successful login submission', async () => {
-    const { wrapper } = renderWithProviders(<div />, { services: { auth: { login: loginMock, refresh: refreshMock, logout: logoutMock, register: registerMock, me: meMock } } })
+    const { wrapper } = renderWithProviders(<div />, {
+      services: {
+        auth: {
+          login: loginMock,
+          refresh: refreshMock,
+          logout: logoutMock,
+          register: registerMock,
+          me: meMock,
+          updateProfile: async () => ({})
+        },
+      },
+    })
 
     render(
       <MemoryRouter initialEntries={["/login"]}>

--- a/frontend/src/lib/spa-signup-drawer.test.tsx
+++ b/frontend/src/lib/spa-signup-drawer.test.tsx
@@ -14,7 +14,18 @@ const meMock = vi.fn(async () => null)
 
 describe('SPA /signup opens Register drawer', () => {
   it('keeps URL at /signup, opens register drawer, and hides duplicate route content', async () => {
-    const { wrapper } = renderWithProviders(<div />, { services: { auth: { login: loginMock, refresh: refreshMock, logout: logoutMock, register: registerMock, me: meMock } } })
+    const { wrapper } = renderWithProviders(<div />, {
+      services: {
+        auth: {
+          login: loginMock,
+          refresh: refreshMock,
+          logout: logoutMock,
+          register: registerMock,
+          me: meMock,
+          updateProfile: async () => ({})
+        },
+      },
+    })
 
     render(
       <MemoryRouter initialEntries={["/signup"]}>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -34,6 +34,7 @@ import NotFoundPage from './pages/not-found'
 import StatusPageRoute from './pages/errors/status-route'
 import UnderConstructionPage from './pages/under-construction'
 import NavigationBuilderPage from './pages/admin/navigation-builder'
+import ProfileSettingsPage from './pages/settings/account/profile'
 
 // Do not force a default theme here; theme is initialized in index.html before React mounts.
 
@@ -132,6 +133,11 @@ const router = createBrowserRouter([
       { path: 'settings/navigation', element: (
         <ProtectedRoute>
           <NavigationBuilderPage />
+        </ProtectedRoute>
+      ) },
+      { path: 'settings/account/profile', element: (
+        <ProtectedRoute>
+          <ProfileSettingsPage />
         </ProtectedRoute>
       ) },
       { path: 'settings/logs', element: (

--- a/frontend/src/pages/admin/navigation-builder.tsx
+++ b/frontend/src/pages/admin/navigation-builder.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/services/hooks/navigationAdmin'
 import type {
   AdminMenu,
+  AdminMenuRecord,
   AdminMenuItem,
   CreateAdminMenuInput,
   UpdateAdminMenuInput,
@@ -184,18 +185,26 @@ function AdminNavigationBuilderPage() {
     error: selectedMenuError,
   } = useAdminMenu(menuParam)
 
-  const createMenuMutation = useMutation((input: CreateAdminMenuInput) => services.admin.navigation.createMenu(input))
-  const updateMenuMutation = useMutation((args: { id: string; input: UpdateAdminMenuInput }) =>
-    services.admin.navigation.updateMenu(args.id, args.input),
-  )
-  const deleteMenuMutation = useMutation((id: string) => services.admin.navigation.deleteMenu(id))
-  const createItemMutation = useMutation((args: { menuId: string; input: CreateAdminMenuItemInput }) =>
-    services.admin.navigation.createMenuItem(args.menuId, args.input),
-  )
-  const updateItemMutation = useMutation((args: { id: string; input: UpdateAdminMenuItemInput }) =>
-    services.admin.navigation.updateMenuItem(args.id, args.input),
-  )
-  const deleteItemMutation = useMutation((id: string) => services.admin.navigation.deleteMenuItem(id))
+  const createMenuMutation = useMutation<AdminMenuRecord, Error, CreateAdminMenuInput>({
+    mutationFn: (input: CreateAdminMenuInput) => services.admin.navigation.createMenu(input),
+  })
+  const updateMenuMutation = useMutation<AdminMenuRecord, Error, { id: string; input: UpdateAdminMenuInput }>({
+    mutationFn: (args: { id: string; input: UpdateAdminMenuInput }) => services.admin.navigation.updateMenu(args.id, args.input),
+  })
+  const deleteMenuMutation = useMutation<void, Error, string>({
+    mutationFn: (id: string) => services.admin.navigation.deleteMenu(id),
+  })
+  const createItemMutation = useMutation<AdminMenuItem, Error, { menuId: string; input: CreateAdminMenuItemInput }>({
+    mutationFn: (args: { menuId: string; input: CreateAdminMenuItemInput }) =>
+      services.admin.navigation.createMenuItem(args.menuId, args.input),
+  })
+  const updateItemMutation = useMutation<AdminMenuItem, Error, { id: string; input: UpdateAdminMenuItemInput }>({
+    mutationFn: (args: { id: string; input: UpdateAdminMenuItemInput }) =>
+      services.admin.navigation.updateMenuItem(args.id, args.input),
+  })
+  const deleteItemMutation = useMutation<void, Error, string>({
+    mutationFn: (id: string) => services.admin.navigation.deleteMenuItem(id),
+  })
 
   const canManageNavigation = React.useMemo(
     () => Boolean(user?.roles?.some((role) => role === 'admin' || role === 'system_admin')),

--- a/frontend/src/pages/admin/settings.test.tsx
+++ b/frontend/src/pages/admin/settings.test.tsx
@@ -4,6 +4,8 @@ import AdminSettingsPage from './settings'
 import { renderWithProviders } from '@/test-utils/renderWithProviders'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter } from 'react-router-dom'
+import type { IAdminNavigationService } from '@/services/interfaces/admin.interface'
+import type { INavigationService } from '@/services/interfaces/navigation.interface'
 
 vi.mock('@/lib/auth-context', () => {
   return {
@@ -48,25 +50,87 @@ const navigationMenuMock = {
   ],
 }
 
-const navigationServiceStub = {
-  listMenus: vi.fn().mockResolvedValue([navigationMenuMock]),
-  getMenu: vi.fn().mockResolvedValue(navigationMenuMock),
-  createMenu: vi.fn().mockResolvedValue(null),
-  updateMenu: vi.fn().mockResolvedValue(null),
-  deleteMenu: vi.fn().mockResolvedValue(undefined),
-  createMenuItem: vi.fn().mockResolvedValue(null),
-  updateMenuItem: vi.fn().mockResolvedValue(null),
-  deleteMenuItem: vi.fn().mockResolvedValue(undefined),
+const listNavigationMenusMock = vi.fn().mockResolvedValue([navigationMenuMock])
+const getNavigationMenuMock = vi.fn().mockResolvedValue(navigationMenuMock)
+
+const navigationServiceStub: INavigationService = {
+  listMenus: listNavigationMenusMock,
+  getMenu: getNavigationMenuMock,
+}
+
+const adminListMenusMock = vi.fn().mockResolvedValue([])
+const adminGetMenuMock = vi.fn().mockResolvedValue(null)
+const adminCreateMenuMock = vi.fn().mockResolvedValue({ id: 'menu-id', name: 'Menu' })
+const adminUpdateMenuMock = vi.fn().mockResolvedValue({ id: 'menu-id', name: 'Menu' })
+const adminDeleteMenuMock = vi.fn().mockResolvedValue(undefined)
+const adminListMenuItemsMock = vi.fn().mockResolvedValue([])
+const adminCreateMenuItemMock = vi.fn().mockResolvedValue({
+    id: 'item-id',
+    menuId: 'menu-id',
+    parentId: null,
+    title: 'Item',
+    url: null,
+    icon: null,
+    target: null,
+    external: null,
+    order: 0,
+    meta: null,
+    isVisible: true,
+    isPublished: true,
+    locale: null,
+    createdAt: null,
+    updatedAt: null,
+    children: [],
+  }),
+const adminUpdateMenuItemMock = vi.fn().mockResolvedValue({
+    id: 'item-id',
+    menuId: 'menu-id',
+    parentId: null,
+    title: 'Item',
+    url: null,
+    icon: null,
+    target: null,
+    external: null,
+    order: 0,
+    meta: null,
+    isVisible: true,
+    isPublished: true,
+    locale: null,
+    createdAt: null,
+    updatedAt: null,
+    children: [],
+  }),
+const adminDeleteMenuItemMock = vi.fn().mockResolvedValue(undefined)
+
+const adminNavigationServiceStub: IAdminNavigationService = {
+  listMenus: adminListMenusMock,
+  getMenu: adminGetMenuMock,
+  createMenu: adminCreateMenuMock,
+  updateMenu: adminUpdateMenuMock,
+  deleteMenu: adminDeleteMenuMock,
+  listMenuItems: adminListMenuItemsMock,
+  createMenuItem: adminCreateMenuItemMock,
+  updateMenuItem: adminUpdateMenuItemMock,
+  deleteMenuItem: adminDeleteMenuItemMock,
 }
 
 describe('AdminSettingsPage (Security)', () => {
   beforeEach(() => {
     saveSettingsMock.mockClear()
     loadSettingsMock.mockClear()
-    navigationServiceStub.listMenus.mockClear()
-    navigationServiceStub.listMenus.mockResolvedValue([navigationMenuMock])
-    navigationServiceStub.getMenu.mockClear()
-    navigationServiceStub.getMenu.mockResolvedValue(navigationMenuMock)
+    listNavigationMenusMock.mockClear()
+    listNavigationMenusMock.mockResolvedValue([navigationMenuMock])
+    getNavigationMenuMock.mockClear()
+    getNavigationMenuMock.mockResolvedValue(navigationMenuMock)
+    adminListMenusMock.mockClear()
+    adminGetMenuMock.mockClear()
+    adminCreateMenuMock.mockClear()
+    adminUpdateMenuMock.mockClear()
+    adminDeleteMenuMock.mockClear()
+    adminListMenuItemsMock.mockClear()
+    adminCreateMenuItemMock.mockClear()
+    adminUpdateMenuItemMock.mockClear()
+    adminDeleteMenuItemMock.mockClear()
   })
 
   it('saves security settings including new thresholds', async () => {
@@ -74,6 +138,7 @@ describe('AdminSettingsPage (Security)', () => {
       services: {
         admin: {
           settings: { loadSettings: loadSettingsMock, saveSettings: saveSettingsMock },
+          navigation: adminNavigationServiceStub,
         },
         navigation: navigationServiceStub,
       },
@@ -112,6 +177,7 @@ describe('AdminSettingsPage (Security)', () => {
       services: {
         admin: {
           settings: { loadSettings: loadSettingsMock, saveSettings: saveSettingsMock },
+          navigation: adminNavigationServiceStub,
         },
         navigation: navigationServiceStub,
       },
@@ -160,6 +226,7 @@ describe('AdminSettingsPage (Access control)', () => {
             services={{
               admin: {
                 settings: { loadSettings: loadSettingsMock, saveSettings: saveSettingsMock },
+                navigation: adminNavigationServiceStub,
               },
               navigation: navigationServiceStub,
             }}

--- a/frontend/src/pages/settings/account/profile.test.tsx
+++ b/frontend/src/pages/settings/account/profile.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import ProfileSettingsPage from "./profile"
+import type { UserDetail } from "@/services/interfaces/types"
+
+const baseUser: UserDetail = {
+  id: "user-1",
+  email: "avery@example.com",
+  name: "Avery Handler",
+  roles: ["staff", "admin"],
+  permissions: ["settings:read"],
+  lock: null,
+  image: "https://cdn.example.com/avatar.png",
+  createdAt: "2024-01-05T10:00:00.000Z",
+  updatedAt: "2024-02-01T18:30:00.000Z",
+  lastLoginAt: "2024-02-10T12:45:00.000Z",
+  metadata: {
+    title: "Director",
+    department: "Shelter Ops",
+    pronouns: "she/her",
+    timezone: "America/Los_Angeles",
+    locale: "en-US",
+    phone: "555-555-1234",
+    bio: "Oversees day-to-day operations.",
+  },
+}
+
+function cloneUser(): UserDetail {
+  return JSON.parse(JSON.stringify(baseUser)) as UserDetail
+}
+
+let currentUser: UserDetail | null = cloneUser()
+let initializingFlag = false
+const updateProfileMock = vi.fn()
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({
+    user: currentUser,
+    updateProfile: updateProfileMock,
+    initializing: initializingFlag,
+    authenticated: true,
+    login: vi.fn(),
+    register: vi.fn(),
+    logout: vi.fn(),
+    setUser: vi.fn(),
+  }),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+describe("ProfileSettingsPage", () => {
+  beforeEach(() => {
+    currentUser = cloneUser()
+    initializingFlag = false
+    updateProfileMock.mockReset()
+  })
+
+  afterEach(() => {
+    currentUser = cloneUser()
+    initializingFlag = false
+  })
+
+  it("prefills the form with existing profile data", () => {
+    render(<ProfileSettingsPage />)
+
+    expect(screen.getByLabelText(/Full name/i)).toHaveValue("Avery Handler")
+    expect(screen.getByLabelText(/Title/i)).toHaveValue("Director")
+    expect(screen.getByLabelText(/Department/i)).toHaveValue("Shelter Ops")
+    expect(screen.getByLabelText(/Pronouns/i)).toHaveValue("she/her")
+    expect(screen.getByLabelText(/Timezone/i)).toHaveValue("America/Los_Angeles")
+    expect(screen.getByLabelText(/Locale/i)).toHaveValue("en-US")
+    expect(screen.getByLabelText(/Phone/i)).toHaveValue("555-555-1234")
+    expect(screen.getByLabelText(/Avatar image URL/i)).toHaveValue("https://cdn.example.com/avatar.png")
+    expect(screen.getByLabelText(/Bio/i)).toHaveValue("Oversees day-to-day operations.")
+  })
+
+  it("submits updates with normalized payload", async () => {
+    updateProfileMock.mockResolvedValue({
+      ...cloneUser(),
+      name: "Avery H.",
+      metadata: {
+        ...baseUser.metadata,
+        bio: "Ready to help every pet find a home.",
+      },
+    })
+
+    render(<ProfileSettingsPage />)
+
+    fireEvent.change(screen.getByLabelText(/Full name/i), { target: { value: "Avery H." } })
+    fireEvent.change(screen.getByLabelText(/Bio/i), { target: { value: "Ready to help every pet find a home." } })
+
+    const saveButton = screen.getByRole("button", { name: /save changes/i })
+    fireEvent.click(saveButton)
+
+    await waitFor(() => expect(updateProfileMock).toHaveBeenCalledTimes(1))
+
+    expect(updateProfileMock.mock.calls[0][0]).toMatchObject({
+      name: "Avery H.",
+      bio: "Ready to help every pet find a home.",
+    })
+
+    expect(screen.getByLabelText(/Full name/i)).toHaveValue("Avery H.")
+    expect(saveButton).toBeDisabled()
+  })
+
+  it("renders a loading state while auth context initializes", () => {
+    initializingFlag = true
+    currentUser = null
+
+    render(<ProfileSettingsPage />)
+
+    expect(screen.getByText(/Loading profile/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/settings/account/profile.tsx
+++ b/frontend/src/pages/settings/account/profile.tsx
@@ -1,0 +1,383 @@
+import * as React from "react"
+import { useAuth } from "@/lib/auth-context"
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Separator } from "@/components/ui/separator"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import type { UserDetail, UserProfileUpdateInput } from "@/services/interfaces/types"
+import { toast } from "sonner"
+
+const PLACEHOLDER_AVATAR = "/avatars/shadcn.jpg"
+
+type FormState = {
+  name: string
+  avatarUrl: string
+  title: string
+  department: string
+  pronouns: string
+  timezone: string
+  locale: string
+  phone: string
+  bio: string
+}
+
+const EMPTY_FORM: FormState = {
+  name: "",
+  avatarUrl: "",
+  title: "",
+  department: "",
+  pronouns: "",
+  timezone: "",
+  locale: "",
+  phone: "",
+  bio: "",
+}
+
+function buildInitialState(user: UserDetail | null | undefined): FormState {
+  if (!user) return { ...EMPTY_FORM }
+  const metadata = user.metadata && typeof user.metadata === "object" && !Array.isArray(user.metadata)
+    ? (user.metadata as Record<string, unknown>)
+    : {}
+  const readMeta = (key: string): string => {
+    const value = metadata[key]
+    return typeof value === "string" ? value : ""
+  }
+  return {
+    name: user.name ?? "",
+    avatarUrl: typeof user.image === "string" ? user.image ?? "" : "",
+    title: readMeta("title"),
+    department: readMeta("department"),
+    pronouns: readMeta("pronouns"),
+    timezone: readMeta("timezone"),
+    locale: readMeta("locale"),
+    phone: readMeta("phone"),
+    bio: readMeta("bio"),
+  }
+}
+
+function normalizeInput(value: string): string | null {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function safeAvatarSource(form: FormState, user: UserDetail | null): string {
+  if (form.avatarUrl.trim().length > 0) return form.avatarUrl.trim()
+  const meta = user?.metadata && typeof user.metadata === "object" && !Array.isArray(user.metadata)
+    ? (user.metadata as Record<string, unknown>)
+    : null
+  const metaAvatar = meta?.["avatarUrl"]
+  if (typeof metaAvatar === "string" && metaAvatar.trim().length > 0) return metaAvatar.trim()
+  if (user?.image && typeof user.image === "string" && user.image.trim().length > 0) return user.image.trim()
+  return PLACEHOLDER_AVATAR
+}
+
+function makeInitials(user: UserDetail | null): string {
+  const source = (user?.name || user?.email || "User").trim()
+  if (!source) return "U"
+  const parts = source.split(/\s+/)
+  if (parts.length >= 2) {
+    const a = parts[0]?.[0] ?? ""
+    const b = parts[1]?.[0] ?? ""
+    const initials = `${a}${b}`.trim()
+    return initials ? initials.toUpperCase() : "U"
+  }
+  return source.slice(0, 2).toUpperCase() || "U"
+}
+
+function formatDate(value?: string | null): string {
+  if (!value) return "—"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date)
+}
+
+export default function ProfileSettingsPage() {
+  const { user, updateProfile, initializing } = useAuth()
+  const [form, setForm] = React.useState<FormState>(() => buildInitialState(user))
+  const [baseline, setBaseline] = React.useState<FormState>(() => buildInitialState(user))
+  const [saving, setSaving] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!user) return
+    const next = buildInitialState(user)
+    setForm(next)
+    setBaseline(next)
+  }, [user?.id, user?.updatedAt, user?.name, user?.image, user?.metadata])
+
+  const isDirty = React.useMemo(() => JSON.stringify(form) !== JSON.stringify(baseline), [form, baseline])
+
+  const handleChange = React.useCallback((field: keyof FormState, value: string) => {
+    setForm((prev) => ({ ...prev, [field]: value }))
+  }, [])
+
+  const handleReset = React.useCallback(() => {
+    setForm(baseline)
+    setError(null)
+  }, [baseline])
+
+  const handleSubmit = React.useCallback(async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!isDirty) return
+    setSaving(true)
+    setError(null)
+    try {
+      const payload: UserProfileUpdateInput = {
+        name: normalizeInput(form.name),
+        avatarUrl: normalizeInput(form.avatarUrl),
+        title: normalizeInput(form.title),
+        department: normalizeInput(form.department),
+        pronouns: normalizeInput(form.pronouns),
+        timezone: normalizeInput(form.timezone),
+        locale: normalizeInput(form.locale),
+        phone: normalizeInput(form.phone),
+        bio: normalizeInput(form.bio),
+      }
+      const updated = await updateProfile(payload)
+      const refreshed = buildInitialState(updated ?? user)
+      setBaseline(refreshed)
+      setForm(refreshed)
+      toast.success("Profile updated")
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to update profile"
+      setError(message)
+      toast.error(message)
+    } finally {
+      setSaving(false)
+    }
+  }, [form, isDirty, updateProfile, user])
+
+  if (initializing) {
+    return (
+      <div className="p-6">
+        <div className="text-sm text-muted-foreground">Loading profile…</div>
+      </div>
+    )
+  }
+
+  if (!user) {
+    return (
+      <div className="p-6">
+        <Alert variant="destructive">
+          <AlertTitle>Profile unavailable</AlertTitle>
+          <AlertDescription>We could not load your profile details.</AlertDescription>
+        </Alert>
+      </div>
+    )
+  }
+
+  const avatarSrc = safeAvatarSource(form, user)
+  const initials = makeInitials(user)
+  const roles = Array.isArray(user.roles) ? user.roles : []
+  const phoneDisplay = form.phone.trim() || "—"
+  const lastUpdated = formatDate(user.updatedAt)
+  const createdAt = formatDate(user.createdAt)
+  const lastLoginAt = formatDate((user as any).lastLoginAt)
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">Profile</h1>
+        <p className="text-sm text-muted-foreground">
+          Keep your contact details and personal preferences up to date.
+        </p>
+      </div>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTitle>Update failed</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile information</CardTitle>
+            <CardDescription>These details are visible to team members with access to your account.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-6" onSubmit={handleSubmit}>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="profile-name">Full name</Label>
+                  <Input
+                    id="profile-name"
+                    value={form.name}
+                    onChange={(event) => handleChange("name", event.target.value)}
+                    placeholder="Ada Lovelace"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="profile-title">Title</Label>
+                  <Input
+                    id="profile-title"
+                    value={form.title}
+                    onChange={(event) => handleChange("title", event.target.value)}
+                    placeholder="Director of Operations"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="profile-department">Department</Label>
+                  <Input
+                    id="profile-department"
+                    value={form.department}
+                    onChange={(event) => handleChange("department", event.target.value)}
+                    placeholder="Shelter Services"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="profile-pronouns">Pronouns</Label>
+                  <Input
+                    id="profile-pronouns"
+                    value={form.pronouns}
+                    onChange={(event) => handleChange("pronouns", event.target.value)}
+                    placeholder="she/her"
+                  />
+                </div>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="profile-timezone">Timezone</Label>
+                  <Input
+                    id="profile-timezone"
+                    value={form.timezone}
+                    onChange={(event) => handleChange("timezone", event.target.value)}
+                    placeholder="America/Los_Angeles"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="profile-locale">Locale</Label>
+                  <Input
+                    id="profile-locale"
+                    value={form.locale}
+                    onChange={(event) => handleChange("locale", event.target.value)}
+                    placeholder="en-US"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="profile-phone">Phone</Label>
+                  <Input
+                    id="profile-phone"
+                    value={form.phone}
+                    onChange={(event) => handleChange("phone", event.target.value)}
+                    placeholder="(555) 123-4567"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="profile-avatar">Avatar image URL</Label>
+                  <Input
+                    id="profile-avatar"
+                    value={form.avatarUrl}
+                    onChange={(event) => handleChange("avatarUrl", event.target.value)}
+                    placeholder="https://example.com/avatar.png"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="profile-bio">Bio</Label>
+                <Textarea
+                  id="profile-bio"
+                  value={form.bio}
+                  onChange={(event) => handleChange("bio", event.target.value)}
+                  placeholder="Share a short summary to help teammates get to know you."
+                  rows={5}
+                />
+                <p className="text-xs text-muted-foreground">Maximum 1,000 characters.</p>
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <Button type="submit" disabled={!isDirty || saving}>
+                  {saving ? "Saving…" : "Save changes"}
+                </Button>
+                <Button type="button" variant="outline" onClick={handleReset} disabled={!isDirty || saving}>
+                  Discard changes
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Preview</CardTitle>
+              <CardDescription>Snapshot of how your profile appears across the workspace.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center gap-4">
+                <Avatar className="h-16 w-16">
+                  <AvatarImage src={avatarSrc} alt={user.name || user.email || "User avatar"} />
+                  <AvatarFallback>{initials}</AvatarFallback>
+                </Avatar>
+                <div className="space-y-1">
+                  <div className="text-lg font-semibold leading-tight">{form.name || user.name || user.email}</div>
+                  <div className="text-sm text-muted-foreground">
+                    {[form.title, form.department].filter(Boolean).join(" • ") || "Add a title"}
+                  </div>
+                  <div className="text-xs text-muted-foreground">Last updated {lastUpdated}</div>
+                </div>
+              </div>
+              <Separator />
+              <div className="space-y-3 text-sm">
+                <div>
+                  <div className="text-muted-foreground">Email</div>
+                  <div className="font-medium">{user.email}</div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">Phone</div>
+                  <div className="font-medium">{phoneDisplay}</div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">Timezone</div>
+                  <div className="font-medium">{form.timezone.trim() || "—"}</div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">Locale</div>
+                  <div className="font-medium">{form.locale.trim() || "—"}</div>
+                </div>
+              </div>
+              <Separator />
+              <div className="space-y-2">
+                <div className="text-muted-foreground text-sm">Roles</div>
+                {roles.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {roles.map((role) => (
+                      <Badge key={role} variant="secondary">{role}</Badge>
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-sm text-muted-foreground">No roles assigned</div>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Account activity</CardTitle>
+              <CardDescription>Timestamps reflect your current session timezone.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div>
+                <div className="text-muted-foreground">Member since</div>
+                <div className="font-medium">{createdAt}</div>
+              </div>
+              <div>
+                <div className="text-muted-foreground">Last login</div>
+                <div className="font-medium">{lastLoginAt}</div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/impl/authAdapter.ts
+++ b/frontend/src/services/impl/authAdapter.ts
@@ -3,6 +3,7 @@
 // instead use the service interfaces under `services/interfaces`.
 import * as api from '../../lib/api';
 import type { IAuthService } from '../interfaces/auth.interface';
+import type { UserProfileUpdateInput } from '../interfaces/types';
 
 export class AuthAdapter implements IAuthService {
   async login(input: { email: string; password: string }) {
@@ -37,6 +38,9 @@ export class AuthAdapter implements IAuthService {
   }
   async me() {
     return api.me();
+  }
+  async updateProfile(input: UserProfileUpdateInput) {
+    return api.updateProfile(input);
   }
 }
 

--- a/frontend/src/services/interfaces/auth.interface.ts
+++ b/frontend/src/services/interfaces/auth.interface.ts
@@ -1,3 +1,5 @@
+import type { UserProfileUpdateInput } from './types';
+
 export interface IAuthService {
   login(input: { email: string; password: string }): Promise<any>;
   register(input: { email: string; password: string; name?: string }): Promise<any>;
@@ -8,4 +10,5 @@ export interface IAuthService {
    * This encapsulates the runtime '/auth/me' call so callers don't use fetch directly.
    */
   me(): Promise<any | null>;
+  updateProfile(input: UserProfileUpdateInput): Promise<any>;
 }

--- a/frontend/src/services/interfaces/types/index.ts
+++ b/frontend/src/services/interfaces/types/index.ts
@@ -8,7 +8,22 @@ export type UserSummary = { id: string; email: string; name?: string | null; rol
 export type UserSummaryWithLock = UserSummary & { lock: { reason: string; until: string | null } | null };
 
 export type UserDetail = UserSummaryWithLock & {
+  image?: string | null;
+  permissions?: string[];
   createdAt?: string | null;
   lastLoginAt?: string | null;
+  updatedAt?: string | null;
   metadata?: Record<string, unknown> | null;
+};
+
+export type UserProfileUpdateInput = {
+  name?: string | null;
+  avatarUrl?: string | null;
+  title?: string | null;
+  department?: string | null;
+  pronouns?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
+  phone?: string | null;
+  bio?: string | null;
 };


### PR DESCRIPTION
This PR adds a comprehensive, idempotent `settings_main` seed to populate the admin settings navigation used by the frontend.\n\n- Adds grouped parent items and child links for Account & Profile, Organization, Security & Access, Integrations & API, Billing & Subscription, Monitoring & Reliability, Documentation & Support.\n- Idempotent: guarded by checking existing menu items.\n\nPlease review routes/URLs and meta if you want different paths.